### PR TITLE
follow changes in Modal

### DIFF
--- a/ai-models-modal/main.py
+++ b/ai-models-modal/main.py
@@ -18,9 +18,9 @@ logger = config.get_logger(__name__, add_handler=False)
 
 @stub.function(
     image=stub.image,
-    secret=config.ENV_SECRETS,
+    secrets=[config.ENV_SECRETS],
     network_file_systems={str(config.CACHE_DIR): volume},
-    timeout=300,
+    timeout=80_000,
 )
 def prepare_gfs_analysis(
     model_name: str = "panguweather",
@@ -187,7 +187,7 @@ def prepare_gfs_analysis(
 
 @stub.function(
     image=stub.image,
-    secret=config.ENV_SECRETS,
+    secrets=[config.ENV_SECRETS],
     network_file_systems={str(config.CACHE_DIR): volume},
     # gpu="T4",
     timeout=60,
@@ -250,7 +250,7 @@ def check_assets(skip_validate_env: bool = False):
 
 
 @stub.cls(
-    secret=config.ENV_SECRETS,
+    secrets=[config.ENV_SECRETS],
     gpu=config.DEFAULT_GPU_CONFIG,
     network_file_systems={str(config.CACHE_DIR): volume},
     concurrency_limit=1,
@@ -439,7 +439,7 @@ def _maybe_download_assets(model_name: str) -> None:
         )
         if not target_blob.exists():
             logger.info("  Template not found; generating from scratch.")
-            make_model_era5_template(model_name)
+            make_model_era5_template.remote(model_name)
 
         logger.info(
             "Downloading pre-computed template from gs://%s/%s",
@@ -451,7 +451,7 @@ def _maybe_download_assets(model_name: str) -> None:
 
 @stub.function(
     image=stub.image,
-    secret=config.ENV_SECRETS,
+    secrets=[config.ENV_SECRETS],
     network_file_systems={str(config.CACHE_DIR): volume},
     allow_cross_region_volumes=True,
     timeout=1_800,
@@ -521,7 +521,7 @@ def generate_forecast(
 
 @stub.function(
     image=stub.image,
-    secret=config.ENV_SECRETS,
+    secrets=[config.ENV_SECRETS],
     network_file_systems={str(config.CACHE_DIR): volume},
     timeout=7_200,
     allow_cross_region_volumes=True,

--- a/ai-models-modal/main.py
+++ b/ai-models-modal/main.py
@@ -447,7 +447,7 @@ def _maybe_download_assets(model_name: str) -> None:
         )
         if not target_blob.exists():
             logger.info("  Template not found; generating from scratch.")
-            make_model_era5_template.remote(model_name)
+            make_model_era5_template.local(model_name)
 
         logger.info(
             "Downloading pre-computed template from gs://%s/%s",

--- a/ai-models-modal/main.py
+++ b/ai-models-modal/main.py
@@ -20,7 +20,7 @@ logger = config.get_logger(__name__, add_handler=False)
     image=stub.image,
     secrets=[config.ENV_SECRETS],
     network_file_systems={str(config.CACHE_DIR): volume},
-    timeout=80_000,
+    timeout=300,
 )
 def prepare_gfs_analysis(
     model_name: str = "panguweather",


### PR DESCRIPTION
- Modal has deprecated the `secret` parameter in `stub.function`: now `secrets` should be used instead. Updated usages.
- Make the `make_model_era5_template` call explicitly `.local()`